### PR TITLE
Add Drive/Docs/Sheets/Slides read tools and scope reconsent

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ A Model Context Protocol server for Google Workspace services. This server provi
   - Support for multiple calendars
   - Custom timezone support
 
+- **Drive / Docs / Sheets / Slides (read-only)**
+  - List and fetch Drive file metadata
+  - Export Google Docs/Sheets/Slides via Drive
+  - Download non-Google-native files as resources
+  - Read Docs body text
+  - Read Sheets ranges (single or batch)
+  - Read Slides text content per slide
+
 ## Example Prompts
 
 Try these example prompts with your AI assistant:
@@ -41,6 +49,9 @@ Try these example prompts with your AI assistant:
 - "What do I have on my agenda tomorrow?"
 - "Check my private account's Family agenda for next week"
 - "I need to plan an event with Tim for 2hrs next week. Suggest some time slots"
+- "List my Drive docs and fetch the latest meeting notes"
+- "Read the `Sheet1!A1:D20` range from spreadsheet ABC"
+- "Pull text from my Slides deck to draft a summary"
 
 ## Prerequisites
 
@@ -85,9 +96,13 @@ Google Workspace (G Suite) APIs require OAuth2 authorization. Follow these steps
    ```json
    [
      "openid",
+  "https://www.googleapis.com/auth/userinfo.email",
      "https://mail.google.com/",
-     "https://www.googleapis.com/auth/calendar",
-     "https://www.googleapis.com/auth/userinfo.email"
+  "https://www.googleapis.com/auth/calendar",
+  "https://www.googleapis.com/auth/drive.readonly",
+  "https://www.googleapis.com/auth/documents.readonly",
+  "https://www.googleapis.com/auth/spreadsheets.readonly",
+  "https://www.googleapis.com/auth/presentations.readonly"
    ]
    ```
 
@@ -248,6 +263,34 @@ On Windows: Edit `%APPDATA%/Claude/claude_desktop_config.json`
    - Delete events by ID
    - Option for cancellation notifications
 
+### Drive Tools
+
+1. `drive_list_files`
+   - List files with optional Drive query
+2. `drive_get_file_metadata`
+   - Retrieve metadata for a file by ID
+3. `drive_export_file`
+   - Export Google Docs/Sheets/Slides to a target mime type (e.g., text/plain)
+4. `drive_download_file`
+   - Download non-Google-native files as embedded resources
+
+### Docs Tools
+
+1. `docs_get_document`
+   - Return the text content of a Google Doc
+
+### Sheets Tools
+
+1. `sheets_get_values`
+   - Read a range from a Google Sheet
+2. `sheets_batch_get_values`
+   - Read multiple ranges in a single call
+
+### Slides Tools
+
+1. `slides_get_presentation`
+   - Return slide text content for a presentation
+
 ## Development
 
 - Source code is in TypeScript under the `src/` directory
@@ -265,7 +308,11 @@ mcp-google-workspace/
 │   │   └── gauth.ts        # Google authentication service
 │   ├── tools/
 │   │   ├── gmail.ts        # Gmail tools implementation
-│   │   └── calendar.ts     # Calendar tools implementation
+│   │   ├── calendar.ts     # Calendar tools implementation
+│   │   ├── drive.ts        # Drive tools implementation
+│   │   ├── docs.ts         # Docs tools implementation
+│   │   ├── sheets.ts       # Sheets tools implementation
+│   │   └── slides.ts       # Slides tools implementation
 │   └── types/
 │       └── tool-handler.ts # Common types and interfaces
 ├── .gauth.json             # OAuth2 credentials

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -1,0 +1,93 @@
+import { Tool, TextContent } from '@modelcontextprotocol/sdk/types.js';
+import { google } from 'googleapis';
+import { GAuthService } from '../services/gauth.js';
+import { USER_ID_ARG } from '../types/tool-handler.js';
+
+export class DocsTools {
+  private docs: ReturnType<typeof google.docs>;
+
+  constructor(private gauth: GAuthService) {
+    this.docs = google.docs({ version: 'v1', auth: this.gauth.getClient() });
+  }
+
+  getTools(): Tool[] {
+    return [
+      {
+        name: 'docs_get_document',
+        description: 'Retrieves a Google Docs document and returns its text content.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            [USER_ID_ARG]: {
+              type: 'string',
+              description: 'Email address of the user'
+            },
+            document_id: {
+              type: 'string',
+              description: 'The ID of the Google Docs document'
+            }
+          },
+          required: ['document_id', USER_ID_ARG]
+        }
+      }
+    ];
+  }
+
+  async handleTool(name: string, args: Record<string, any>): Promise<Array<TextContent>> {
+    switch (name) {
+      case 'docs_get_document':
+        return this.getDocument(args);
+      default:
+        throw new Error(`Unknown tool: ${name}`);
+    }
+  }
+
+  private ensureUserId(args: Record<string, any>): string {
+    const userId = args[USER_ID_ARG];
+    if (!userId) {
+      throw new Error(`Missing required argument: ${USER_ID_ARG}`);
+    }
+    return userId;
+  }
+
+  private extractText(content: any[] = []): string {
+    const lines: string[] = [];
+
+    for (const element of content) {
+      if (element.paragraph?.elements) {
+        const textRuns = element.paragraph.elements
+          .map((el: any) => el.textRun?.content || '')
+          .join('');
+
+        const cleaned = textRuns.trimEnd();
+        if (cleaned) {
+          lines.push(cleaned);
+        }
+      }
+    }
+
+    return lines.join('\n');
+  }
+
+  private async getDocument(args: Record<string, any>): Promise<Array<TextContent>> {
+    this.ensureUserId(args);
+    const documentId = args.document_id;
+    if (!documentId) {
+      throw new Error('Missing required argument: document_id');
+    }
+
+    const response = await this.docs.documents.get({ documentId });
+    const doc = response.data;
+    const text = this.extractText(doc.body?.content || []);
+
+    return [{
+      type: 'text',
+      text: JSON.stringify({
+        documentId,
+        title: doc.title,
+        text
+      }, null, 2)
+    }];
+  }
+}
+

--- a/src/tools/drive.ts
+++ b/src/tools/drive.ts
@@ -1,0 +1,222 @@
+import { Tool, TextContent, EmbeddedResource } from '@modelcontextprotocol/sdk/types.js';
+import { google } from 'googleapis';
+import { GAuthService } from '../services/gauth.js';
+import { USER_ID_ARG } from '../types/tool-handler.js';
+
+const DEFAULT_EXPORT_MIME = 'text/plain';
+
+export class DriveTools {
+  private drive: ReturnType<typeof google.drive>;
+
+  constructor(private gauth: GAuthService) {
+    this.drive = google.drive({ version: 'v3', auth: this.gauth.getClient() });
+  }
+
+  getTools(): Tool[] {
+    return [
+      {
+        name: 'drive_list_files',
+        description: 'Lists files in Google Drive with optional query and mimeType filters.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            [USER_ID_ARG]: {
+              type: 'string',
+              description: 'Email address of the user'
+            },
+            query: {
+              type: 'string',
+              description: 'Drive query string (e.g., "mimeType contains \'application/vnd.google-apps\'")'
+            },
+            page_size: {
+              type: 'integer',
+              description: 'Number of files to return (1-100)',
+              minimum: 1,
+              maximum: 100,
+              default: 50
+            }
+          },
+          required: [USER_ID_ARG]
+        }
+      },
+      {
+        name: 'drive_get_file_metadata',
+        description: 'Retrieves metadata for a Drive file by ID.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            [USER_ID_ARG]: {
+              type: 'string',
+              description: 'Email address of the user'
+            },
+            file_id: {
+              type: 'string',
+              description: 'The ID of the Drive file'
+            }
+          },
+          required: ['file_id', USER_ID_ARG]
+        }
+      },
+      {
+        name: 'drive_export_file',
+        description: 'Exports a Google Docs/Sheets/Slides file to the specified mime type (defaults to text/plain).',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            [USER_ID_ARG]: {
+              type: 'string',
+              description: 'Email address of the user'
+            },
+            file_id: {
+              type: 'string',
+              description: 'The ID of the Drive file'
+            },
+            export_mime_type: {
+              type: 'string',
+              description: 'Target mime type to export (e.g., text/plain, text/csv, application/pdf)',
+              default: DEFAULT_EXPORT_MIME
+            }
+          },
+          required: ['file_id', USER_ID_ARG]
+        }
+      },
+      {
+        name: 'drive_download_file',
+        description: 'Downloads a non-Google-native Drive file by ID and returns it as an embedded resource.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            [USER_ID_ARG]: {
+              type: 'string',
+              description: 'Email address of the user'
+            },
+            file_id: {
+              type: 'string',
+              description: 'The ID of the Drive file'
+            },
+            filename: {
+              type: 'string',
+              description: 'Optional filename hint for the resource'
+            },
+            mime_type: {
+              type: 'string',
+              description: 'Optional mime type hint for the resource'
+            }
+          },
+          required: ['file_id', USER_ID_ARG]
+        }
+      }
+    ];
+  }
+
+  async handleTool(name: string, args: Record<string, any>): Promise<Array<TextContent | EmbeddedResource>> {
+    switch (name) {
+      case 'drive_list_files':
+        return this.listFiles(args);
+      case 'drive_get_file_metadata':
+        return this.getFileMetadata(args);
+      case 'drive_export_file':
+        return this.exportFile(args);
+      case 'drive_download_file':
+        return this.downloadFile(args);
+      default:
+        throw new Error(`Unknown tool: ${name}`);
+    }
+  }
+
+  private ensureUserId(args: Record<string, any>): string {
+    const userId = args[USER_ID_ARG];
+    if (!userId) {
+      throw new Error(`Missing required argument: ${USER_ID_ARG}`);
+    }
+    return userId;
+  }
+
+  private async listFiles(args: Record<string, any>): Promise<Array<TextContent>> {
+    this.ensureUserId(args);
+    const pageSize = Math.min(Math.max(1, args.page_size || 50), 100);
+
+    const response = await this.drive.files.list({
+      q: args.query,
+      pageSize,
+      fields: 'files(id, name, mimeType, modifiedTime, owners(displayName, emailAddress))'
+    });
+
+    return [{
+      type: 'text',
+      text: JSON.stringify(response.data.files || [], null, 2)
+    }];
+  }
+
+  private async getFileMetadata(args: Record<string, any>): Promise<Array<TextContent>> {
+    this.ensureUserId(args);
+    const fileId = args.file_id;
+    if (!fileId) {
+      throw new Error('Missing required argument: file_id');
+    }
+
+    const response = await this.drive.files.get({
+      fileId,
+      fields: 'id, name, mimeType, modifiedTime, size, webViewLink, owners(displayName, emailAddress)'
+    });
+
+    return [{
+      type: 'text',
+      text: JSON.stringify(response.data, null, 2)
+    }];
+  }
+
+  private async exportFile(args: Record<string, any>): Promise<Array<TextContent>> {
+    this.ensureUserId(args);
+    const fileId = args.file_id;
+    const exportMimeType = args.export_mime_type || DEFAULT_EXPORT_MIME;
+
+    if (!fileId) {
+      throw new Error('Missing required argument: file_id');
+    }
+
+    const response = await this.drive.files.export(
+      { fileId, mimeType: exportMimeType },
+      { responseType: 'arraybuffer' }
+    );
+
+    const buffer = Buffer.from(response.data as ArrayBuffer);
+    const text = buffer.toString('utf-8');
+
+    return [{
+      type: 'text',
+      text
+    }];
+  }
+
+  private async downloadFile(args: Record<string, any>): Promise<Array<EmbeddedResource>> {
+    this.ensureUserId(args);
+    const fileId = args.file_id;
+    if (!fileId) {
+      throw new Error('Missing required argument: file_id');
+    }
+
+    const metadata = await this.drive.files.get({
+      fileId,
+      fields: 'id, name, mimeType'
+    });
+
+    const response = await this.drive.files.get(
+      { fileId, alt: 'media' },
+      { responseType: 'arraybuffer' }
+    );
+
+    const buffer = Buffer.from(response.data as ArrayBuffer);
+    const mimeType = args.mime_type || metadata.data.mimeType || 'application/octet-stream';
+
+    return [{
+      type: 'resource',
+      resource: {
+        uri: `urn:drive:${fileId}`,
+        mimeType,
+        blob: buffer.toString('base64')
+      }
+    }];
+  }
+}
+

--- a/src/tools/sheets.ts
+++ b/src/tools/sheets.ts
@@ -1,0 +1,128 @@
+import { Tool, TextContent } from '@modelcontextprotocol/sdk/types.js';
+import { google } from 'googleapis';
+import { GAuthService } from '../services/gauth.js';
+import { USER_ID_ARG } from '../types/tool-handler.js';
+
+export class SheetsTools {
+  private sheets: ReturnType<typeof google.sheets>;
+
+  constructor(private gauth: GAuthService) {
+    this.sheets = google.sheets({ version: 'v4', auth: this.gauth.getClient() });
+  }
+
+  getTools(): Tool[] {
+    return [
+      {
+        name: 'sheets_get_values',
+        description: 'Reads values from a Google Sheet range (read-only).',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            [USER_ID_ARG]: {
+              type: 'string',
+              description: 'Email address of the user'
+            },
+            spreadsheet_id: {
+              type: 'string',
+              description: 'The ID of the Google Sheet'
+            },
+            range: {
+              type: 'string',
+              description: 'Range to read (e.g., Sheet1!A1:D20)'
+            },
+            major_dimension: {
+              type: 'string',
+              description: 'Optional major dimension (ROWS or COLUMNS)',
+              enum: ['ROWS', 'COLUMNS']
+            }
+          },
+          required: ['spreadsheet_id', 'range', USER_ID_ARG]
+        }
+      },
+      {
+        name: 'sheets_batch_get_values',
+        description: 'Reads multiple ranges from a Google Sheet in one call.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            [USER_ID_ARG]: {
+              type: 'string',
+              description: 'Email address of the user'
+            },
+            spreadsheet_id: {
+              type: 'string',
+              description: 'The ID of the Google Sheet'
+            },
+            ranges: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Array of ranges to read (e.g., ["Sheet1!A1:C5", "Sheet2!A1:B3"])'
+            }
+          },
+          required: ['spreadsheet_id', 'ranges', USER_ID_ARG]
+        }
+      }
+    ];
+  }
+
+  async handleTool(name: string, args: Record<string, any>): Promise<Array<TextContent>> {
+    switch (name) {
+      case 'sheets_get_values':
+        return this.getValues(args);
+      case 'sheets_batch_get_values':
+        return this.batchGetValues(args);
+      default:
+        throw new Error(`Unknown tool: ${name}`);
+    }
+  }
+
+  private ensureUserId(args: Record<string, any>): string {
+    const userId = args[USER_ID_ARG];
+    if (!userId) {
+      throw new Error(`Missing required argument: ${USER_ID_ARG}`);
+    }
+    return userId;
+  }
+
+  private async getValues(args: Record<string, any>): Promise<Array<TextContent>> {
+    this.ensureUserId(args);
+    const spreadsheetId = args.spreadsheet_id;
+    const range = args.range;
+
+    if (!spreadsheetId || !range) {
+      throw new Error('Missing required arguments: spreadsheet_id or range');
+    }
+
+    const response = await this.sheets.spreadsheets.values.get({
+      spreadsheetId,
+      range,
+      majorDimension: args.major_dimension
+    });
+
+    return [{
+      type: 'text',
+      text: JSON.stringify(response.data, null, 2)
+    }];
+  }
+
+  private async batchGetValues(args: Record<string, any>): Promise<Array<TextContent>> {
+    this.ensureUserId(args);
+    const spreadsheetId = args.spreadsheet_id;
+    const ranges = args.ranges;
+
+    if (!spreadsheetId || !ranges || ranges.length === 0) {
+      throw new Error('Missing required arguments: spreadsheet_id or ranges');
+    }
+
+    const response = await this.sheets.spreadsheets.values.batchGet({
+      spreadsheetId,
+      ranges
+    });
+
+    return [{
+      type: 'text',
+      text: JSON.stringify(response.data, null, 2)
+    }];
+  }
+}
+

--- a/src/tools/slides.ts
+++ b/src/tools/slides.ts
@@ -1,0 +1,102 @@
+import { Tool, TextContent } from '@modelcontextprotocol/sdk/types.js';
+import { google } from 'googleapis';
+import { GAuthService } from '../services/gauth.js';
+import { USER_ID_ARG } from '../types/tool-handler.js';
+
+export class SlidesTools {
+  private slides: ReturnType<typeof google.slides>;
+
+  constructor(private gauth: GAuthService) {
+    this.slides = google.slides({ version: 'v1', auth: this.gauth.getClient() });
+  }
+
+  getTools(): Tool[] {
+    return [
+      {
+        name: 'slides_get_presentation',
+        description: 'Retrieves a Google Slides presentation and returns slide text content.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            [USER_ID_ARG]: {
+              type: 'string',
+              description: 'Email address of the user'
+            },
+            presentation_id: {
+              type: 'string',
+              description: 'The ID of the Google Slides presentation'
+            }
+          },
+          required: ['presentation_id', USER_ID_ARG]
+        }
+      }
+    ];
+  }
+
+  async handleTool(name: string, args: Record<string, any>): Promise<Array<TextContent>> {
+    switch (name) {
+      case 'slides_get_presentation':
+        return this.getPresentation(args);
+      default:
+        throw new Error(`Unknown tool: ${name}`);
+    }
+  }
+
+  private ensureUserId(args: Record<string, any>): string {
+    const userId = args[USER_ID_ARG];
+    if (!userId) {
+      throw new Error(`Missing required argument: ${USER_ID_ARG}`);
+    }
+    return userId;
+  }
+
+  private extractSlideText(slide: any): string {
+    const chunks: string[] = [];
+
+    if (!slide.pageElements) {
+      return '';
+    }
+
+    for (const element of slide.pageElements) {
+      if (element.shape?.text?.textElements) {
+        const text = element.shape.text.textElements
+          .map((t: any) => t.textRun?.content || '')
+          .join('')
+          .trim();
+        if (text) {
+          chunks.push(text);
+        }
+      }
+    }
+
+    return chunks.join('\n');
+  }
+
+  private async getPresentation(args: Record<string, any>): Promise<Array<TextContent>> {
+    this.ensureUserId(args);
+    const presentationId = args.presentation_id;
+    if (!presentationId) {
+      throw new Error('Missing required argument: presentation_id');
+    }
+
+    const response = await this.slides.presentations.get({ presentationId });
+    const presentation = response.data;
+    const slides = presentation.slides || [];
+
+    const slideSummaries = slides.map((slide, idx) => ({
+      slideIndex: idx + 1,
+      slideObjectId: slide.objectId,
+      text: this.extractSlideText(slide)
+    }));
+
+    return [{
+      type: 'text',
+      text: JSON.stringify({
+        presentationId,
+        title: presentation.title,
+        slides: slideSummaries
+      }, null, 2)
+    }];
+  }
+}
+


### PR DESCRIPTION
## Summary
- add read-only Drive/Docs/Sheets/Slides toolsets (list/export/download docs/slides text, sheet ranges)
- export scopes and require missing-scope reconsent so new APIs trigger OAuth automatically
- register tools in server, document scopes/examples, and gate Gmail send/reply/draft behind env flag

## Testing
- npm run build