### PR TITLE
fix(gmail): harden attachment downloads & allow drafts without GMAIL_ALLOW_SENDING

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /dist/
 /node_modules/
 /.*.json
+.DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -120,7 +120,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.28.tgz",
       "integrity": "sha512-DHlH/fNL6Mho38jTy7/JT7sn2wnXI+wULR6PV4gy4VHLVvnrV/d3pHAMQHhc4gjdLmK2ZiPoMxzp6B3yRajLSQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -645,7 +644,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.0.1.tgz",
       "integrity": "sha512-ORF7g6qGnD+YtUG9yx4DFoqCShNMmUKiXuT5oWMHiOvt/4WFbHC6yCwQMTSBMno7AqntNCAzzcnnjowRkTL9eQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.0.1",
@@ -1746,7 +1744,6 @@
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1868,7 +1865,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
       "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -1960,7 +1956,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.28.tgz",
       "integrity": "sha512-DHlH/fNL6Mho38jTy7/JT7sn2wnXI+wULR6PV4gy4VHLVvnrV/d3pHAMQHhc4gjdLmK2ZiPoMxzp6B3yRajLSQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "undici-types": "~6.19.2"
       }
@@ -2283,7 +2278,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/express/-/express-5.0.1.tgz",
       "integrity": "sha512-ORF7g6qGnD+YtUG9yx4DFoqCShNMmUKiXuT5oWMHiOvt/4WFbHC6yCwQMTSBMno7AqntNCAzzcnnjowRkTL9eQ==",
-      "peer": true,
       "requires": {
         "accepts": "^2.0.0",
         "body-parser": "^2.0.1",
@@ -2978,8 +2972,7 @@
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "undici-types": {
       "version": "6.19.8",
@@ -3055,8 +3048,7 @@
     "zod": {
       "version": "3.24.2",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
-      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
-      "peer": true
+      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ=="
     },
     "zod-to-json-schema": {
       "version": "3.24.3",

--- a/src/server.ts
+++ b/src/server.ts
@@ -30,6 +30,7 @@ interface ServerConfig {
   gauthFile: string;
   accountsFile: string;
   credentialsDir: string;
+  attachmentsDir?: string;
 }
 
 class OAuthServer {
@@ -78,7 +79,7 @@ class GoogleWorkspaceServer {
     calendar: CalendarTools;
   };
 
-  constructor(config: ServerConfig) {
+  constructor(private config: ServerConfig) {
     logger.info('Starting Google Workspace MCP Server...');
 
     // Initialize services
@@ -94,7 +95,7 @@ class GoogleWorkspaceServer {
   private async initializeTools() {
     // Initialize tools after OAuth2 client is ready
     this.tools = {
-      gmail: new GmailTools(this.gauth),
+      gmail: new GmailTools(this.gauth, this.config.attachmentsDir),
       calendar: new CalendarTools(this.gauth)
     };
 
@@ -277,16 +278,18 @@ class GoogleWorkspaceServer {
 const { values } = parseArgs({
   args: process.argv.slice(2),
   options: {
-    'gauth-file': { type: 'string', default: './.gauth.json' },
-    'accounts-file': { type: 'string', default: './.accounts.json' },
-    'credentials-dir': { type: 'string', default: '.' }
+    'gauth-file':       { type: 'string', default: './.gauth.json' },
+    'accounts-file':    { type: 'string', default: './.accounts.json' },
+    'credentials-dir':  { type: 'string', default: '.' },
+    'attachments-dir':  { type: 'string' }   // optional; defaults to ~/Downloads/mcp-attachments
   }
 });
 
 const config: ServerConfig = {
-  gauthFile: values['gauth-file'] as string,
-  accountsFile: values['accounts-file'] as string,
-  credentialsDir: values['credentials-dir'] as string
+  gauthFile:       values['gauth-file'] as string,
+  accountsFile:    values['accounts-file'] as string,
+  credentialsDir:  values['credentials-dir'] as string,
+  attachmentsDir:  values['attachments-dir'] as string | undefined
 };
 
 // Start the server

--- a/src/tools/gmail.ts
+++ b/src/tools/gmail.ts
@@ -4,6 +4,28 @@ import { google } from 'googleapis';
 import { USER_ID_ARG } from '../types/tool-handler.js';
 import { Buffer } from 'buffer';
 import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+// Default download directory: ~/Downloads/mcp-attachments
+const DEFAULT_ATTACHMENTS_DIR = path.join(os.homedir(), 'Downloads', 'mcp-attachments');
+
+/**
+ * Resolves `userPath` relative to `allowedDir` and throws if the result
+ * would escape outside that directory (path traversal protection).
+ */
+function validateAndResolvePath(userPath: string, allowedDir: string): string {
+  // Strip any leading slashes so the path is always treated as relative
+  const sanitized = path.normalize(userPath).replace(/^(\.\.(\/|\\|$))+/, '');
+  const resolved = path.resolve(allowedDir, sanitized);
+  if (!resolved.startsWith(path.resolve(allowedDir) + path.sep) &&
+      resolved !== path.resolve(allowedDir)) {
+    throw new Error(
+      `Path traversal detected: "${userPath}" resolves outside the allowed directory "${allowedDir}".`
+    );
+  }
+  return resolved;
+}
 
 function decodeBase64Data(fileData: string): Buffer {
   const standardBase64Data = fileData.replace(/-/g, '+').replace(/_/g, '/');
@@ -13,9 +35,13 @@ function decodeBase64Data(fileData: string): Buffer {
 
 export class GmailTools {
   private gmail: ReturnType<typeof google.gmail>;
+  private allowedDir: string;
 
-  constructor(private gauth: GAuthService) {
+  constructor(private gauth: GAuthService, attachmentsDir?: string) {
     this.gmail = google.gmail({ version: 'v1', auth: this.gauth.getClient() });
+    this.allowedDir = path.resolve(attachmentsDir ?? DEFAULT_ATTACHMENTS_DIR);
+    // Ensure the directory exists
+    fs.mkdirSync(this.allowedDir, { recursive: true });
   }
 
   // Helper methods for email content extraction
@@ -820,10 +846,12 @@ export class GmailTools {
       const decodedContent = this.decodeBase64UrlString(decodedData);
 
       if (saveToDisk) {
-        fs.writeFileSync(saveToDisk, decodedContent);
+        const safePath = validateAndResolvePath(saveToDisk, this.allowedDir);
+        fs.mkdirSync(path.dirname(safePath), { recursive: true });
+        fs.writeFileSync(safePath, decodedContent, { mode: 0o600 });
         return [{
           type: 'text',
-          text: `Attachment saved to ${saveToDisk}`
+          text: `Attachment saved to ${safePath}`
         }];
       } else {
         return [{
@@ -873,12 +901,14 @@ export class GmailTools {
           const decodedData = Buffer.from(fileData, 'base64').toString('utf-8');
           const decodedContent = this.decodeBase64UrlString(decodedData);
 
-          fs.writeFileSync(savePath, decodedContent);
+          const safePath = validateAndResolvePath(savePath, this.allowedDir);
+          fs.mkdirSync(path.dirname(safePath), { recursive: true });
+          fs.writeFileSync(safePath, decodedContent, { mode: 0o600 });
 
           return {
             messageId,
             partId,
-            savePath,
+            savePath: safePath,
             status: 'success'
           };
         })

--- a/src/tools/gmail.ts
+++ b/src/tools/gmail.ts
@@ -395,10 +395,17 @@ export class GmailTools {
           required: ['message_ids', USER_ID_ARG]
         }
       }
-    ] as Tool[]).filter(tool => (
-      (process.env.GMAIL_ALLOW_SENDING === 'true')
-      ? true
-      : (tool.name !== 'gmail_reply' && tool.name !== 'gmail_create_draft')));
+    ] as Tool[]).filter(tool => {
+      // Draft creation & deletion are always allowed
+      if (tool.name === 'gmail_create_draft' || tool.name === 'gmail_delete_draft') {
+        return true;
+      }
+      // Reply (which can also save as draft) requires the sending flag
+      if (tool.name === 'gmail_reply') {
+        return process.env.GMAIL_ALLOW_SENDING === 'true';
+      }
+      return true;
+    });
   }
 
   async handleTool(name: string, args: Record<string, any>): Promise<Array<TextContent | ImageContent | EmbeddedResource>> {


### PR DESCRIPTION
## Security hardening & Gmail draft workflow improvements

### Summary

This PR rolls up two focused changes that improve the security posture of attachment downloads and make the Gmail draft workflow more practical for day-to-day use with MCP clients.

### Changes

#### 1. Prevent path traversal in Gmail attachment downloads

- Introduces a `validateAndResolvePath()` helper that normalises user-supplied file names and rejects any path that would escape outside the designated attachments directory.
- Both the single-attachment and bulk-attachment save code paths are now protected.
- Saved files are written with mode `0o600` (owner-only read/write) to reduce accidental exposure.
- The default download location is `~/Downloads/mcp-attachments`, created automatically on server startup.
- A new `--attachments-dir` CLI flag (and optional `ServerConfig.attachmentsDir` field) lets operators override the download directory.

#### 2. Allow draft creation & deletion without `GMAIL_ALLOW_SENDING`

- `gmail_create_draft` and `gmail_delete_draft` are now always registered regardless of the `GMAIL_ALLOW_SENDING` environment variable, since drafts don't actually send mail.
- Only `gmail_reply` (which can transmit email) remains gated behind the sending flag.
- This lets users compose and manage drafts in a safe, read-only-ish mode without opening the sending capability.

#### Housekeeping

- Added `.DS_Store` to `.gitignore`.
- Removed unnecessary `"peer": true` markers from `package-lock.json`.

### Files changed

| File | What changed |
|---|---|
| `src/tools/gmail.ts` | Path-traversal guard, `0o600` file mode, relaxed draft tool filtering |
| `src/server.ts` | `attachmentsDir` config field, `--attachments-dir` CLI flag, pass dir to `GmailTools` |
| `.gitignore` | Ignore `.DS_Store` |
| `package-lock.json` | Removed stale `peer` flags |

### Testing notes

- Verify attachments save to `~/Downloads/mcp-attachments` by default and respect `--attachments-dir`.
- Confirm that `../../etc/passwd`-style paths are rejected with a clear error.
- With `GMAIL_ALLOW_SENDING` unset or `false`, confirm `gmail_create_draft` and `gmail_delete_draft` are listed but `gmail_reply` is not.
