### PR TITLE
fix(auth): add gmail settings reauth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A Model Context Protocol server for Google Workspace services. This server provi
 Try these example prompts with your AI assistant:
 
 ### Gmail
+
 - "Retrieve my latest unread messages"
 - "Search my emails from the Scrum Master"
 - "Retrieve all emails from accounting"
@@ -38,6 +39,7 @@ Try these example prompts with your AI assistant:
 - "Reply to Bob's email with a Thank you note. Store it as draft"
 
 ### Calendar
+
 - "What do I have on my agenda tomorrow?"
 - "Check my private account's Family agenda for next week"
 - "I need to plan an event with Tim for 2hrs next week. Suggest some time slots"
@@ -51,17 +53,20 @@ Try these example prompts with your AI assistant:
 ## Installation
 
 1. Clone the repository:
+
    ```bash
    git clone https://github.com/j3k0/mcp-google-workspace.git
    cd mcp-google-workspace
    ```
 
 2. Install dependencies:
+
    ```bash
    npm install
    ```
 
 3. Build the TypeScript code:
+
    ```bash
    npm run build
    ```
@@ -82,16 +87,19 @@ Google Workspace (G Suite) APIs require OAuth2 authorization. Follow these steps
    - Add authorized redirect URIs (include `http://localhost:4100/code` for local development)
 
 2. Required OAuth2 Scopes:
+
    ```json
    [
      "openid",
      "https://mail.google.com/",
+     "https://www.googleapis.com/auth/gmail.settings.basic",
      "https://www.googleapis.com/auth/calendar",
      "https://www.googleapis.com/auth/userinfo.email"
    ]
    ```
 
 3. Create a `.gauth.json` file in the project root with your Google OAuth 2.0 credentials:
+
    ```json
    {
      "installed": {
@@ -107,6 +115,7 @@ Google Workspace (G Suite) APIs require OAuth2 authorization. Follow these steps
    ```
 
 4. Create a `.accounts.json` file to specify which Google accounts can use the server:
+
    ```json
    {
      "accounts": [
@@ -141,6 +150,7 @@ On Windows: Edit `%APPDATA%/Claude/claude_desktop_config.json`
   }
 }
 ```
+
 </details>
 
 <details>
@@ -158,11 +168,13 @@ On Windows: Edit `%APPDATA%/Claude/claude_desktop_config.json`
   }
 }
 ```
+
 </details>
 
 ## Usage
 
 1. Start the server:
+
    ```bash
    npm start
    ```

--- a/authenticate.js
+++ b/authenticate.js
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+
+// Standalone authentication script for Google Workspace MCP
+// This script authenticates all configured accounts and stores credentials
+
+import { GAuthService } from './dist/services/gauth.js';
+import { createServer } from 'http';
+import { parse as parseUrl } from 'url';
+import { parse as parseQueryString } from 'querystring';
+import open from 'open';
+import * as fs from 'fs/promises';
+
+const config = {
+  gauthFile: '.gauth.json',
+  accountsFile: 'accounts.json',
+  credentialsDir: 'credentials'
+};
+
+const gauth = new GAuthService(config);
+
+function parseCliArgs(argv) {
+  const args = {
+    email: '',
+    force: false
+  };
+
+  for (const arg of argv) {
+    if (arg === '--force') {
+      args.force = true;
+      continue;
+    }
+
+    if (arg.startsWith('--email=')) {
+      args.email = arg.slice('--email='.length);
+      continue;
+    }
+
+    if (!arg.startsWith('--') && !args.email) {
+      args.email = arg;
+    }
+  }
+
+  return args;
+}
+
+async function authenticateAccount(email, force = false) {
+  console.log(`\nAuthenticating ${email}...`);
+
+  // Check if already authenticated
+  const existing = await gauth.getStoredCredentials(email);
+  if (existing && !force) {
+    console.log(`✓ ${email} already authenticated`);
+    return;
+  }
+
+  if (existing && force) {
+    console.log(`Forcing re-authentication for ${email}...`);
+  }
+
+  // Generate auth URL
+  const authUrl = await gauth.getAuthorizationUrl(email, {});
+  console.log(`Opening browser for ${email}...`);
+  console.log(`Auth URL: ${authUrl}`);
+
+  // Open browser
+  open(authUrl);
+
+  // Start HTTP server to receive callback
+  return new Promise((resolve, reject) => {
+    const server = createServer(async (req, res) => {
+      const url = parseUrl(req.url || '');
+
+      if (url.pathname === '/code') {
+        const query = parseQueryString(url.query || '');
+
+        if (query.code) {
+          res.writeHead(200, { 'Content-Type': 'text/html' });
+          res.end('<h1>Authentication successful!</h1><p>You can close this tab.</p>');
+
+          try {
+            await gauth.getCredentials(query.code, {});
+            console.log(`✓ ${email} authenticated successfully`);
+            server.close();
+            resolve();
+          } catch (error) {
+            console.error(`✗ Authentication failed for ${email}:`, error.message);
+            server.close();
+            reject(error);
+          }
+        } else {
+          res.writeHead(400);
+          res.end('Missing authorization code');
+          server.close();
+          reject(new Error('Missing authorization code'));
+        }
+      }
+    });
+
+    server.listen(4100, () => {
+      console.log('Waiting for OAuth callback on http://localhost:4100/code ...');
+    });
+
+    // Timeout after 5 minutes
+    setTimeout(() => {
+      server.close();
+      reject(new Error('Authentication timeout'));
+    }, 300000);
+  });
+}
+
+async function main() {
+  console.log('Google Workspace MCP - Account Authentication\n');
+  const args = parseCliArgs(process.argv.slice(2));
+
+  // Initialize OAuth client
+  await gauth.initialize();
+
+  // Get all configured accounts
+  let accounts = await gauth.getAccountInfo();
+  if (args.email) {
+    accounts = accounts.filter((account) => account.email === args.email);
+    if (accounts.length === 0) {
+      throw new Error(`Account ${args.email} is not configured`);
+    }
+  }
+  console.log(`Found ${accounts.length} configured accounts\n`);
+
+  // Authenticate each account sequentially
+  for (const account of accounts) {
+    try {
+      await authenticateAccount(account.email, args.force);
+    } catch (error) {
+      console.error(`Failed to authenticate ${account.email}:`, error.message);
+    }
+  }
+
+  console.log('\n✓ Authentication complete!');
+}
+
+main().catch(error => {
+  console.error('Fatal error:', error);
+  process.exit(1);
+});

--- a/src/services/gauth.ts
+++ b/src/services/gauth.ts
@@ -11,6 +11,7 @@ const SCOPES = [
   'openid',
   'https://www.googleapis.com/auth/userinfo.email',
   'https://mail.google.com/',
+  'https://www.googleapis.com/auth/gmail.settings.basic',
   'https://www.googleapis.com/auth/calendar'
 ];
 


### PR DESCRIPTION
## Summary
- add `gmail.settings.basic` to the OAuth scope list so Gmail filter create/delete works
- add a standalone reauth helper that can target one account and force consent refresh
- document the added scope in the README

## Why
Gmail filter deletion required `https://www.googleapis.com/auth/gmail.settings.basic` in this integration path. Without it, filter list worked but delete returned insufficient scope errors.

## Verification
- `npm run build`