### PR TITLE
fix(auth): add gmail.settings.basic scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Google Workspace (G Suite) APIs require OAuth2 authorization. Follow these steps
    [
      "openid",
      "https://mail.google.com/",
+     "https://www.googleapis.com/auth/gmail.settings.basic",
      "https://www.googleapis.com/auth/calendar",
      "https://www.googleapis.com/auth/userinfo.email"
    ]

--- a/src/services/gauth.ts
+++ b/src/services/gauth.ts
@@ -11,6 +11,7 @@ const SCOPES = [
   'openid',
   'https://www.googleapis.com/auth/userinfo.email',
   'https://mail.google.com/',
+  'https://www.googleapis.com/auth/gmail.settings.basic',
   'https://www.googleapis.com/auth/calendar'
 ];
 


### PR DESCRIPTION
## Summary
- Add `gmail.settings.basic` to the OAuth scope list so Gmail filter create/delete works
- Document the added scope in the README

## Why
Gmail filter deletion requires `https://www.googleapis.com/auth/gmail.settings.basic`. Without it, filter list works but delete returns insufficient scope errors.

## Note
Split from #15 — this is the scope fix only, the auth helper will be a separate PR.