### PR TITLE
fix(gmail): default to text/html for drafts to preserve line breaks

### DIFF
--- a/src/tools/gmail.ts
+++ b/src/tools/gmail.ts
@@ -225,6 +225,12 @@ export class GmailTools {
                 type: 'string'
               },
               description: 'Optional list of email addresses to CC'
+            },
+            content_type: {
+              type: 'string',
+              enum: ['text/plain', 'text/html'],
+              description: 'Content type of the email body. Defaults to text/html. Plain text bodies are auto-converted (newlines become <br>).',
+              default: 'text/html'
             }
           },
           required: ['to', 'subject', 'body', USER_ID_ARG]
@@ -283,6 +289,12 @@ export class GmailTools {
                 type: 'string'
               },
               description: 'Optional list of email addresses to CC on the reply'
+            },
+            content_type: {
+              type: 'string',
+              enum: ['text/plain', 'text/html'],
+              description: 'Content type of the email body. Defaults to text/html. Plain text bodies are auto-converted (newlines become <br>).',
+              default: 'text/html'
             }
           },
           required: ['original_message_id', 'reply_body', USER_ID_ARG]
@@ -645,12 +657,25 @@ export class GmailTools {
     }
   }
 
+  private formatEmailBody(body: string, contentType: string): string {
+    if (contentType === 'text/html') {
+      // If the body doesn't contain HTML tags, convert plain text to HTML
+      if (!/<[a-z][\s\S]*>/i.test(body)) {
+        return body.replace(/\r\n/g, '\n').replace(/\n/g, '<br>\n');
+      }
+      return body;
+    }
+    // For text/plain, normalize line endings to CRLF (RFC 2822)
+    return body.replace(/\r\n/g, '\n').replace(/\n/g, '\r\n');
+  }
+
   private async createDraft(args: Record<string, any>): Promise<Array<TextContent>> {
     const userId = args[USER_ID_ARG];
     const to = Array.isArray(args.to) ? args.to.join(', ') : args.to;
     const subject = args.subject;
     const body = args.body;
     const cc = args.cc || [];
+    const contentType = args.content_type || 'text/html';
 
     if (!userId) {
       throw new Error(`Missing required argument: ${USER_ID_ARG}`);
@@ -666,14 +691,15 @@ export class GmailTools {
     }
 
     try {
+      const formattedBody = this.formatEmailBody(body, contentType);
       const message = {
         raw: Buffer.from(
           `To: ${this.sanitizeHeader(to)}\r\n` +
           `Subject: ${this.sanitizeHeader(subject)}\r\n` +
           `Cc: ${cc.map((c: string) => this.sanitizeHeader(c)).join(', ')}\r\n` +
-          `Content-Type: text/plain; charset="UTF-8"\r\n` +
+          `Content-Type: ${contentType}; charset="UTF-8"\r\n` +
           `\r\n` +
-          `${body}`
+          `${formattedBody}`
         ).toString('base64url')
       };
 
@@ -727,6 +753,7 @@ export class GmailTools {
     const replyBody = args.reply_body;
     const send = (process.env.GMAIL_ALLOW_SENDING === 'true') ? (args.send || false) : false;
     const cc = args.cc || [];
+    const contentType = args.content_type || 'text/html';
 
     if (!userId) {
       throw new Error(`Missing required argument: ${USER_ID_ARG}`);
@@ -762,6 +789,7 @@ export class GmailTools {
         throw new Error('Could not extract threadId from original message');
       }
 
+      const formattedReplyBody = this.formatEmailBody(replyBody, contentType);
       const message = {
         raw: Buffer.from(
           `In-Reply-To: ${this.sanitizeHeader(originalMessageId)}\r\n` +
@@ -769,9 +797,9 @@ export class GmailTools {
           `Subject: Re: ${this.sanitizeHeader(headers.subject || '')}\r\n` +
           `To: ${this.sanitizeHeader(headers.from || '')}\r\n` +
           `Cc: ${cc.map((c: string) => this.sanitizeHeader(c)).join(', ')}\r\n` +
-          `Content-Type: text/plain; charset="UTF-8"\r\n` +
+          `Content-Type: ${contentType}; charset="UTF-8"\r\n` +
           `\r\n` +
-          `${replyBody}`
+          `${formattedReplyBody}`
         ).toString('base64url'),
         threadId: threadId
       };


### PR DESCRIPTION
## Problem

Gmail does not render `\n` newline characters in `text/plain` emails. When an AI agent creates a draft via `gmail_create_draft` or `gmail_reply`, the resulting email body appears as a single block of text with no line breaks or formatting.

This was tested with both the Gmail API raw MIME messages (this server) and Anthropic's built-in Gmail MCP integration — `text/plain` fails to preserve line breaks in both cases.

## Solution

- Add a `content_type` parameter to `gmail_create_draft` and `gmail_reply` (`text/plain` | `text/html`, defaults to `text/html`)
- Add a `formatEmailBody()` helper that:
  - **For `text/html`**: auto-converts plain text bodies (`\n` → `<br>`) when no HTML tags are detected; passes through bodies that already contain HTML
  - **For `text/plain`**: normalizes line endings to CRLF per RFC 2822

## Backward compatibility

This change is fully backward-compatible:

| Agent sends | `content_type` | Result |
|---|---|---|
| Plain text with `\n` | omitted (default `text/html`) | `\n` auto-converted to `<br>`, renders correctly |
| HTML body | omitted (default `text/html`) | Passed through as-is |
| Plain text with `\n` | `text/plain` | CRLF-normalized, but Gmail may still not render line breaks |
| Any | `text/html` | Explicit HTML mode |

Agents that currently send plain text with newlines will get correct rendering **without any changes on their side**.

## Testing

Tested manually by creating drafts via the MCP server and verifying in the Gmail web UI:

- ✅ `text/html` with `<br>` tags: line breaks render correctly
- ✅ `text/html` with plain text body (auto-converted): line breaks render correctly  
- ❌ `text/plain` with `\n`: line breaks are lost (this is the bug being fixed)
- ❌ `text/plain` with `\r\n` (CRLF): line breaks are still lost

🤖 Generated with [Claude Code](https://claude.com/claude-code)