### PR TITLE
fix(gmail): correctly decode attachment data as binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "build": "tsc",
     "start": "node --loader ts-node/esm src/server.ts",
     "dev": "node --loader ts-node/esm src/server.ts",
-    "authenticate": "node --loader ts-node/esm src/authenticate.ts"
+    "authenticate": "node --loader ts-node/esm src/authenticate.ts",
+    "test": "npm run build && node --test 'dist/tools/__tests__/**/*.test.js'"
   }
 }

--- a/src/tools/__tests__/decodeBase64Data.test.ts
+++ b/src/tools/__tests__/decodeBase64Data.test.ts
@@ -1,0 +1,47 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Buffer } from 'buffer';
+import { decodeBase64Data } from '../gmail.js';
+
+test('decodes standard base64 ASCII payload', () => {
+  const input = Buffer.from('Hello, world!', 'utf-8').toString('base64');
+  assert.equal(decodeBase64Data(input).toString('utf-8'), 'Hello, world!');
+});
+
+test('decodes URL-safe base64 (- and _ instead of + and /)', () => {
+  // 0xFB 0xFF 0xBF -> standard base64 "+/+/" -> url-safe "-_-_"
+  const raw = Buffer.from([0xfb, 0xff, 0xbf, 0xfb, 0xff, 0xbf]);
+  const urlSafe = raw.toString('base64').replace(/\+/g, '-').replace(/\//g, '_');
+  assert.ok(urlSafe.includes('-') || urlSafe.includes('_'));
+  assert.deepEqual(decodeBase64Data(urlSafe), raw);
+});
+
+test('decodes payload with missing padding', () => {
+  // "any carnal pleas" -> base64 ends with no '='; strip any '=' to simulate Gmail-style output
+  const raw = Buffer.from('any carnal pleas', 'utf-8');
+  const stripped = raw.toString('base64').replace(/=+$/, '');
+  assert.deepEqual(decodeBase64Data(stripped), raw);
+});
+
+test('preserves binary bytes (PDF magic number)', () => {
+  // %PDF-1.4\n
+  const pdfHeader = Buffer.from([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34, 0x0a]);
+  const encoded = pdfHeader.toString('base64');
+  const decoded = decodeBase64Data(encoded);
+  assert.deepEqual(decoded, pdfHeader);
+  assert.equal(decoded.subarray(0, 5).toString('ascii'), '%PDF-');
+});
+
+test('round-trips arbitrary binary payload', () => {
+  const random = Buffer.from(Array.from({ length: 256 }, (_, i) => i));
+  const urlSafe = random
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+  assert.deepEqual(decodeBase64Data(urlSafe), random);
+});
+
+test('returns empty Buffer for empty input', () => {
+  assert.deepEqual(decodeBase64Data(''), Buffer.alloc(0));
+});

--- a/src/tools/gmail.ts
+++ b/src/tools/gmail.ts
@@ -6,7 +6,7 @@ import { Buffer } from 'buffer';
 import fs from 'fs';
 import * as path from 'path';
 
-function decodeBase64Data(fileData: string): Buffer {
+export function decodeBase64Data(fileData: string): Buffer {
   const standardBase64Data = fileData.replace(/-/g, '+').replace(/_/g, '/');
   const padding = '='.repeat((4 - standardBase64Data.length % 4) % 4);
   return Buffer.from(standardBase64Data + padding, 'base64');
@@ -22,17 +22,11 @@ export class GmailTools {
   // Helper methods for email content extraction
   private decodeBase64UrlString(base64UrlString: string): string {
     try {
-      return this.decodeBase64UrlToBuffer(base64UrlString).toString('utf-8');
+      return decodeBase64Data(base64UrlString).toString('utf-8');
     } catch (error) {
       console.error('Error decoding base64 string:', error);
       return '[Error decoding content]';
     }
-  }
-
-  private decodeBase64UrlToBuffer(base64UrlString: string): Buffer {
-    const base64String = base64UrlString.replace(/-/g, '+').replace(/_/g, '/');
-    const padding = '='.repeat((4 - base64String.length % 4) % 4);
-    return Buffer.from(base64String + padding, 'base64');
   }
 
   /**
@@ -845,7 +839,7 @@ export class GmailTools {
         throw new Error('Attachment data not found');
       }
 
-      const decodedBuffer = this.decodeBase64UrlToBuffer(attachmentData);
+      const decodedBuffer = decodeBase64Data(attachmentData);
 
       if (saveToDisk) {
         const validatedPath = this.validateSavePath(saveToDisk);
@@ -899,7 +893,7 @@ export class GmailTools {
             throw new Error('Attachment data not found');
           }
 
-          const decodedBuffer = this.decodeBase64UrlToBuffer(fileData);
+          const decodedBuffer = decodeBase64Data(fileData);
 
           const validatedPath = this.validateSavePath(savePath);
           fs.writeFileSync(validatedPath, decodedBuffer);

--- a/src/tools/gmail.ts
+++ b/src/tools/gmail.ts
@@ -22,14 +22,17 @@ export class GmailTools {
   // Helper methods for email content extraction
   private decodeBase64UrlString(base64UrlString: string): string {
     try {
-      const base64String = base64UrlString.replace(/-/g, '+').replace(/_/g, '/');
-      const padding = '='.repeat((4 - base64String.length % 4) % 4);
-      const base64 = base64String + padding;
-      return Buffer.from(base64, 'base64').toString('utf-8');
+      return this.decodeBase64UrlToBuffer(base64UrlString).toString('utf-8');
     } catch (error) {
       console.error('Error decoding base64 string:', error);
       return '[Error decoding content]';
     }
+  }
+
+  private decodeBase64UrlToBuffer(base64UrlString: string): Buffer {
+    const base64String = base64UrlString.replace(/-/g, '+').replace(/_/g, '/');
+    const padding = '='.repeat((4 - base64String.length % 4) % 4);
+    return Buffer.from(base64String + padding, 'base64');
   }
 
   /**
@@ -842,12 +845,11 @@ export class GmailTools {
         throw new Error('Attachment data not found');
       }
 
-      const decodedData = Buffer.from(attachmentData, 'base64').toString('utf-8');
-      const decodedContent = this.decodeBase64UrlString(decodedData);
+      const decodedBuffer = this.decodeBase64UrlToBuffer(attachmentData);
 
       if (saveToDisk) {
         const validatedPath = this.validateSavePath(saveToDisk);
-        fs.writeFileSync(validatedPath, decodedContent);
+        fs.writeFileSync(validatedPath, decodedBuffer);
         return [{
           type: 'text',
           text: `Attachment saved to ${validatedPath}`
@@ -855,7 +857,7 @@ export class GmailTools {
       } else {
         return [{
           type: 'text',
-          text: decodedContent
+          text: decodedBuffer.toString('utf-8')
         }];
       }
     } catch (error) {
@@ -897,11 +899,10 @@ export class GmailTools {
             throw new Error('Attachment data not found');
           }
 
-          const decodedData = Buffer.from(fileData, 'base64').toString('utf-8');
-          const decodedContent = this.decodeBase64UrlString(decodedData);
+          const decodedBuffer = this.decodeBase64UrlToBuffer(fileData);
 
           const validatedPath = this.validateSavePath(savePath);
-          fs.writeFileSync(validatedPath, decodedContent);
+          fs.writeFileSync(validatedPath, decodedBuffer);
 
           return {
             messageId,


### PR DESCRIPTION
## Summary

- `gmail_get_attachment` and `gmail_bulk_save_attachments` corrupted every non-text attachment because the payload from the Gmail API was double-decoded: `Buffer.from(data, 'base64').toString('utf-8')` then `decodeBase64UrlString` on the resulting garbage. URL-safe base64 chars (`-`, `_`) weren't handled by the first step either.
- Decode the URL-safe base64 once into a `Buffer` and write the raw bytes to disk. Factor the URL-safe → `Buffer` step into a helper and reuse it from the existing string decoder so the text path is unchanged.

## Test plan

- [x] `npm run build` passes
- [ ] Download a PDF attachment via `gmail_get_attachment` with `save_to_disk` → file opens correctly
- [ ] Bulk save mixed attachments (PDF + PNG + text) via `gmail_bulk_save_attachments` → all files intact