### PR TITLE
fix(gmail): make gmail_list_drafts resilient to per-draft failures

### DIFF
--- a/src/tools/__tests__/formatDraftEntry.test.ts
+++ b/src/tools/__tests__/formatDraftEntry.test.ts
@@ -1,0 +1,75 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { formatDraftEntry } from '../gmail-helpers.js';
+
+test('returns minimal shape when message is null', () => {
+  assert.deepEqual(formatDraftEntry('draft-1', null), {
+    draft_id: 'draft-1',
+    message_id: null,
+  });
+});
+
+test('returns minimal shape when message is undefined', () => {
+  assert.deepEqual(formatDraftEntry('draft-1', undefined), {
+    draft_id: 'draft-1',
+    message_id: null,
+  });
+});
+
+test('returns minimal shape when message has no id', () => {
+  assert.deepEqual(
+    formatDraftEntry('draft-1', { threadId: 't', snippet: 'x' }),
+    { draft_id: 'draft-1', message_id: null }
+  );
+});
+
+test('returns full shape with lowercased headers', () => {
+  const out = formatDraftEntry('draft-1', {
+    id: 'msg-1',
+    threadId: 'thread-1',
+    internalDate: '1234567890',
+    snippet: 'hello',
+    payload: {
+      headers: [
+        { name: 'Subject', value: 'Test' },
+        { name: 'From', value: 'a@b.com' },
+        { name: 'To', value: 'c@d.com' },
+      ],
+    },
+  });
+  assert.equal(out.draft_id, 'draft-1');
+  assert.equal(out.message_id, 'msg-1');
+  assert.equal(out.threadId, 'thread-1');
+  assert.equal(out.internalDate, '1234567890');
+  assert.equal(out.snippet, 'hello');
+  assert.deepEqual(out.headers, {
+    subject: 'Test',
+    from: 'a@b.com',
+    to: 'c@d.com',
+  });
+});
+
+test('skips headers with missing name or value', () => {
+  const out = formatDraftEntry('draft-1', {
+    id: 'msg-1',
+    payload: {
+      headers: [
+        { name: 'Subject', value: 'Test' },
+        { name: 'Empty' },
+        { value: 'orphan' },
+        { name: 'Blank', value: '' },
+      ],
+    },
+  });
+  assert.deepEqual(out.headers, { subject: 'Test' });
+});
+
+test('returns empty headers when payload is missing', () => {
+  const out = formatDraftEntry('draft-1', { id: 'msg-1' });
+  assert.deepEqual(out.headers, {});
+});
+
+test('returns empty headers when payload.headers is null', () => {
+  const out = formatDraftEntry('draft-1', { id: 'msg-1', payload: { headers: null } });
+  assert.deepEqual(out.headers, {});
+});

--- a/src/tools/gmail-helpers.ts
+++ b/src/tools/gmail-helpers.ts
@@ -47,3 +47,50 @@ export function resolveAttachmentPath(filePath: string): string {
   }
   return resolved;
 }
+
+interface MessageHeaderLike {
+  name?: string | null;
+  value?: string | null;
+}
+
+export interface DraftMessageLike {
+  id?: string | null;
+  threadId?: string | null;
+  internalDate?: string | null;
+  snippet?: string | null;
+  payload?: {
+    headers?: MessageHeaderLike[] | null;
+  } | null;
+}
+
+export interface DraftEntry {
+  draft_id: string;
+  message_id: string | null;
+  threadId?: string | null;
+  internalDate?: string | null;
+  snippet?: string | null;
+  headers?: Record<string, string>;
+}
+
+/**
+ * Shapes a single (draft, message) pair into the public response entry
+ * for gmail_list_drafts. Headers are lowercased; entries with no
+ * underlying message return a minimal { draft_id, message_id: null }.
+ */
+export function formatDraftEntry(draftId: string, message: DraftMessageLike | null | undefined): DraftEntry {
+  if (!message || !message.id) {
+    return { draft_id: draftId, message_id: null };
+  }
+  const headers: Record<string, string> = {};
+  message.payload?.headers?.forEach(h => {
+    if (h.name && h.value) headers[h.name.toLowerCase()] = h.value;
+  });
+  return {
+    draft_id: draftId,
+    message_id: message.id,
+    threadId: message.threadId,
+    internalDate: message.internalDate,
+    snippet: message.snippet,
+    headers,
+  };
+}

--- a/src/tools/gmail.ts
+++ b/src/tools/gmail.ts
@@ -4,9 +4,9 @@ import { google } from 'googleapis';
 import { USER_ID_ARG } from '../types/tool-handler.js';
 import { Buffer } from 'buffer';
 import fs from 'fs';
-import { decodeBase64Data, resolveAttachmentPath } from './gmail-helpers.js';
+import { decodeBase64Data, formatDraftEntry, resolveAttachmentPath } from './gmail-helpers.js';
 
-export { decodeBase64Data, resolveAttachmentPath } from './gmail-helpers.js';
+export { decodeBase64Data, formatDraftEntry, resolveAttachmentPath } from './gmail-helpers.js';
 
 export class GmailTools {
   private gmail: ReturnType<typeof google.gmail>;
@@ -722,32 +722,31 @@ export class GmailTools {
       });
 
       const drafts = response.data.drafts || [];
-      const enriched = await Promise.all(
+      const settled = await Promise.allSettled(
         drafts.map(async (d) => {
           const messageId = d.message?.id;
-          if (!messageId) {
-            return { draft_id: d.id, message_id: null };
-          }
+          if (!messageId) return null;
           const msg = await this.gmail.users.messages.get({
             userId,
             id: messageId,
             format: 'metadata',
             metadataHeaders: ['From', 'To', 'Cc', 'Subject', 'Date']
           });
-          const headers: Record<string, string> = {};
-          msg.data.payload?.headers?.forEach(h => {
-            if (h.name && h.value) headers[h.name.toLowerCase()] = h.value;
-          });
-          return {
-            draft_id: d.id,
-            message_id: messageId,
-            threadId: msg.data.threadId,
-            internalDate: msg.data.internalDate,
-            snippet: msg.data.snippet,
-            headers
-          };
+          return msg.data;
         })
       );
+
+      const enriched = settled.map((result, i) => {
+        const draftId = drafts[i].id ?? '';
+        if (result.status === 'fulfilled') {
+          return formatDraftEntry(draftId, result.value);
+        }
+        return {
+          draft_id: draftId,
+          message_id: drafts[i].message?.id ?? null,
+          error: result.reason instanceof Error ? result.reason.message : String(result.reason),
+        };
+      });
 
       return [{
         type: 'text',


### PR DESCRIPTION
## Summary

Follow-up to #20.

- `listDrafts` previously used `Promise.all` to enrich each draft with `messages.get`. A single failed lookup (tombstoned draft, transient API error, …) rejected the entire response, hiding every other draft on the page.
- Switch to `Promise.allSettled`. Rejected entries now surface as `{ draft_id, message_id, error: "<message>" }`; successful ones keep the same shape as before.
- Extract the per-entry shaping into a pure `formatDraftEntry(draftId, message)` helper in `gmail-helpers.ts` so it can be unit-tested without pulling `googleapis` into the test process.

No public shape change for successful entries. New `error` field appears only when a per-draft fetch fails.

## Test plan

- [x] `npm test` — 22/22 passing (7 new `formatDraftEntry` tests + 15 pre-existing).
- [x] `npm run build`.
- [ ] Manual: live `gmail_list_drafts` call still returns the same fields for healthy drafts (verified locally; relevant output already covered by #20's live test).