### PR TITLE
docs: add CLAUDE.md with dev notes and lessons

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,20 @@
+# mcp-google-workspace
+
+## Dev
+
+- `npm test` builds then runs `node --test` against compiled JS in `dist/tools/__tests__/`
+- Tests import from `gmail-helpers.ts`, never `gmail.ts` — gmail.ts pulls `googleapis` which crashes on Node ≥ 23
+- Use Node 22 to run the server (`/opt/homebrew/opt/node@22/bin/node`); Node 25 fails at import
+- For live MCP testing, register in `.mcp.json` (gitignored via `/.*.json`) with the Node 22 binary explicitly, NOT `./launch`
+- `/reload-plugins` does not respawn project-scope MCP servers — full Claude Code restart required after rebuilding `dist/`
+
+## Conventions
+
+- Tool-owned IDs: snake_case (`draft_id`, `message_id`); Gmail-API-pass-through: camelCase (`threadId`, `internalDate`)
+- Feature gates: `GMAIL_ALLOW_*` env vars; sandbox dirs: `GMAIL_*_DIR`
+
+## Lessons
+
+- [node-version.md](lessons/node-version.md) — Node 25 breaks googleapis transitively
+- [test-isolation.md](lessons/test-isolation.md) — Pure helpers in `gmail-helpers.ts`, never `gmail.ts`
+- [mcp-local-testing.md](lessons/mcp-local-testing.md) — Wiring `.mcp.json` against the local server

--- a/lessons/mcp-local-testing.md
+++ b/lessons/mcp-local-testing.md
@@ -1,0 +1,26 @@
+# Local MCP testing
+
+To live-test the local server against real Gmail (e.g. after a code change
+touching tool behavior), register it in `.mcp.json` at the repo root
+(already covered by `.gitignore`'s `/.*.json` rule):
+
+```json
+{
+  "mcpServers": {
+    "mcp-gsuite-local": {
+      "command": "/opt/homebrew/opt/node@22/bin/node",
+      "args": ["<repo>/dist/server.js"],
+      "env": {}
+    }
+  }
+}
+```
+
+Workflow:
+1. `npm run build` (or `npm test`, which builds first)
+2. Fully restart Claude Code — `/reload-plugins` does NOT respawn project
+   MCP servers; the running process keeps the old `dist/` in memory.
+3. New tool schemas surface after restart.
+
+OAuth tokens live in `.oauth2.*.json` (gitignored). If they're missing,
+run `npm run authenticate` first.

--- a/lessons/node-version.md
+++ b/lessons/node-version.md
@@ -1,0 +1,9 @@
+# Node version
+
+`googleapis` transitively pulls `buffer-equal-constant-time`, which uses
+`require('buffer').SlowBuffer` — removed in Node ≥ 23. The server crashes
+at import time on Node 25 with `TypeError: Cannot read properties of
+undefined (reading 'prototype')`.
+
+Workaround: invoke with Node 22 (`/opt/homebrew/opt/node@22/bin/node`).
+Proper fix lives upstream in googleapis' tree; not trivially patchable here.

--- a/lessons/test-isolation.md
+++ b/lessons/test-isolation.md
@@ -1,0 +1,9 @@
+# Test isolation
+
+`src/tools/gmail.ts` imports `googleapis`, which breaks on Node ≥ 23 (see
+node-version.md). To keep `node:test` runnable on whichever Node the
+contributor has, pure logic lives in `src/tools/gmail-helpers.ts` (zero
+googleapis dependency). Tests import from `gmail-helpers.js`, never `gmail.js`.
+
+When adding testable logic to `gmail.ts`, extract it to `gmail-helpers.ts`
+first and have `gmail.ts` import + re-export it for backward compat.


### PR DESCRIPTION
## Summary

Captures non-obvious project context discovered while working on the recent attachment / drafts PRs (#21, #22, #20, #23):

- **Node 25 incompatibility**: `googleapis` transitively imports `buffer-equal-constant-time`, which uses removed `SlowBuffer`. The server crashes at import on Node ≥ 23 — must use Node 22 explicitly.
- **Test isolation pattern**: pure helpers live in `src/tools/gmail-helpers.ts` (no `googleapis` dep) so `node:test` can run them without dragging the broken import chain in.
- **Naming conventions**: snake_case for tool-owned IDs, camelCase for fields passed through from the Gmail API. `GMAIL_ALLOW_*` for feature gates, `GMAIL_*_DIR` for sandbox paths.
- **Local MCP testing**: how to register the local server in a (gitignored) `.mcp.json` for end-to-end testing against real Gmail, and the gotcha that `/reload-plugins` does not respawn project-scope MCP servers.

Layout follows the maintainer's preferred convention (top-level `CLAUDE.md` with a `# Lessons` section pointing into `lessons/*.md`).

## Test plan

- [x] No code changes — documentation only.
- [x] `lessons/` files render cleanly on GitHub.