### PR TITLE
docs: add Dockerfile for MCP server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+dist
+.git
+.gauth.json
+.accounts.json
+.oauth2.*.json
+.env
+npm-debug.log*
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:20-slim AS build
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build
+
+FROM node:20-slim AS runtime
+
+ENV NODE_ENV=production
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+COPY --from=build /app/dist ./dist
+
+CMD ["node", "dist/server.js"]

--- a/README.md
+++ b/README.md
@@ -188,6 +188,24 @@ On Windows: Edit `%APPDATA%/Claude/claude_desktop_config.json`
 ```
 </details>
 
+### Docker
+
+You can also build and run the MCP server in Docker:
+
+```bash
+docker build -t mcp-google-workspace .
+docker run --rm -i \
+  -v "$PWD/.gauth.json:/app/.gauth.json:ro" \
+  -v "$PWD/.accounts.json:/app/.accounts.json:ro" \
+  -v "$PWD/.credentials:/app/.credentials" \
+  -e GMAIL_ALLOW_DRAFTS=true \
+  -e GMAIL_ATTACHMENTS_DIR=/app/attachments \
+  mcp-google-workspace \
+  node dist/server.js --credentials-dir /app/.credentials
+```
+
+Do not bake `.gauth.json`, `.accounts.json`, OAuth tokens, or `.env` files into the image. The included `.dockerignore` excludes those files; mount them at runtime instead.
+
 ## Usage
 
 1. Start the server:


### PR DESCRIPTION
Closes #3.

## Summary
- add a Dockerfile for running the MCP server in containerized MCP directories
- add a .dockerignore to keep images small and avoid local artifacts
- document Docker build and run commands in the README

## Testing
- git diff --check
- Not run: Docker build, because the local Docker daemon is unavailable
- Not run: npm test, because dependency installation was interrupted by a network reset in my environment