### PR TITLE
feat(gmail): support plain/html/markdown body types for drafts and replies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@modelcontextprotocol/sdk": "^1.6.0",
         "dotenv": "^16.0.0",
         "googleapis": "^133.0.0",
+        "marked": "^18.0.3",
         "open": "^11.0.0"
       },
       "bin": {
@@ -1061,6 +1062,18 @@
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/marked": {
+      "version": "18.0.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.3.tgz",
+      "integrity": "sha512-7VT90JOkDeaRWpfjOReRGPEKn0ecdARBkDGL+tT1wZY0efPPqkUxLUSmzy/C7TIylQYJC9STISEsCHrqb/7VIA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -2426,6 +2439,11 @@
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
+    },
+    "marked": {
+      "version": "18.0.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.3.tgz",
+      "integrity": "sha512-7VT90JOkDeaRWpfjOReRGPEKn0ecdARBkDGL+tT1wZY0efPPqkUxLUSmzy/C7TIylQYJC9STISEsCHrqb/7VIA=="
     },
     "math-intrinsics": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@modelcontextprotocol/sdk": "^1.6.0",
     "dotenv": "^16.0.0",
     "googleapis": "^133.0.0",
+    "marked": "^18.0.3",
     "open": "^11.0.0"
   },
   "devDependencies": {

--- a/src/tools/__tests__/renderEmailBody.test.ts
+++ b/src/tools/__tests__/renderEmailBody.test.ts
@@ -1,0 +1,40 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { renderEmailBody } from '../gmail-helpers.js';
+
+test('defaults to text/plain when body_type is undefined', () => {
+  const out = renderEmailBody('hello\nworld', undefined);
+  assert.equal(out.contentType, 'text/plain');
+  assert.equal(out.body, 'hello\nworld');
+});
+
+test('treats explicit plain as text/plain passthrough', () => {
+  const out = renderEmailBody('hello\nworld', 'plain');
+  assert.equal(out.contentType, 'text/plain');
+  assert.equal(out.body, 'hello\nworld');
+});
+
+test('treats unknown body_type as plain (no surprise behavior change)', () => {
+  const out = renderEmailBody('hello', 'rtf' as any);
+  assert.equal(out.contentType, 'text/plain');
+  assert.equal(out.body, 'hello');
+});
+
+test('passes html through verbatim as text/html', () => {
+  const input = '<p>hi <strong>there</strong></p>';
+  const out = renderEmailBody(input, 'html');
+  assert.equal(out.contentType, 'text/html');
+  assert.equal(out.body, input);
+});
+
+test('renders markdown to html', () => {
+  const out = renderEmailBody('# Title\n\nhello **world**', 'markdown');
+  assert.equal(out.contentType, 'text/html');
+  assert.match(out.body, /<h1[^>]*>Title<\/h1>/);
+  assert.match(out.body, /<strong>world<\/strong>/);
+});
+
+test('markdown returns string body (not a Promise)', () => {
+  const out = renderEmailBody('hello', 'markdown');
+  assert.equal(typeof out.body, 'string');
+});

--- a/src/tools/gmail-helpers.ts
+++ b/src/tools/gmail-helpers.ts
@@ -2,6 +2,7 @@ import { Buffer } from 'buffer';
 import fs from 'fs';
 import os from 'os';
 import * as path from 'path';
+import { marked } from 'marked';
 
 export function decodeBase64Data(fileData: string): Buffer {
   const standardBase64Data = fileData.replace(/-/g, '+').replace(/_/g, '/');
@@ -70,6 +71,32 @@ export interface DraftEntry {
   internalDate?: string | null;
   snippet?: string | null;
   headers?: Record<string, string>;
+}
+
+export type EmailBodyType = 'plain' | 'html' | 'markdown';
+
+export interface RenderedEmailBody {
+  contentType: 'text/plain' | 'text/html';
+  body: string;
+}
+
+/**
+ * Renders the agent-supplied body into the MIME body + Content-Type the
+ * Gmail API should see. 'plain' is passthrough (current behavior),
+ * 'html' is passthrough as text/html, 'markdown' is rendered to HTML
+ * via marked. Defaults to 'plain' when the input is omitted/unknown so
+ * existing callers see no behavior change.
+ */
+export function renderEmailBody(body: string, bodyType: EmailBodyType | string | undefined): RenderedEmailBody {
+  switch (bodyType) {
+    case 'html':
+      return { contentType: 'text/html', body };
+    case 'markdown':
+      return { contentType: 'text/html', body: marked.parse(body, { async: false }) as string };
+    case 'plain':
+    default:
+      return { contentType: 'text/plain', body };
+  }
 }
 
 /**

--- a/src/tools/gmail.ts
+++ b/src/tools/gmail.ts
@@ -4,9 +4,9 @@ import { google } from 'googleapis';
 import { USER_ID_ARG } from '../types/tool-handler.js';
 import { Buffer } from 'buffer';
 import fs from 'fs';
-import { decodeBase64Data, formatDraftEntry, resolveAttachmentPath } from './gmail-helpers.js';
+import { decodeBase64Data, formatDraftEntry, renderEmailBody, resolveAttachmentPath } from './gmail-helpers.js';
 
-export { decodeBase64Data, formatDraftEntry, resolveAttachmentPath } from './gmail-helpers.js';
+export { decodeBase64Data, formatDraftEntry, renderEmailBody, resolveAttachmentPath } from './gmail-helpers.js';
 
 export class GmailTools {
   private gmail: ReturnType<typeof google.gmail>;
@@ -210,6 +210,12 @@ export class GmailTools {
                 type: 'string'
               },
               description: 'Optional list of email addresses to CC'
+            },
+            body_type: {
+              type: 'string',
+              enum: ['plain', 'html', 'markdown'],
+              default: 'plain',
+              description: 'How to interpret `body`. "plain" sends as text/plain (default, current behavior). "html" sends the body verbatim as text/html. "markdown" renders the body to HTML and sends as text/html.'
             }
           },
           required: ['to', 'subject', 'body', USER_ID_ARG]
@@ -295,6 +301,12 @@ export class GmailTools {
                 type: 'string'
               },
               description: 'Optional list of email addresses to CC on the reply'
+            },
+            body_type: {
+              type: 'string',
+              enum: ['plain', 'html', 'markdown'],
+              default: 'plain',
+              description: 'How to interpret `reply_body`. "plain" sends as text/plain (default, current behavior). "html" sends the body verbatim as text/html. "markdown" renders the body to HTML and sends as text/html.'
             }
           },
           required: ['original_message_id', 'reply_body', USER_ID_ARG]
@@ -680,14 +692,15 @@ export class GmailTools {
     }
 
     try {
+      const rendered = renderEmailBody(body, args.body_type);
       const message = {
         raw: Buffer.from(
           `To: ${this.sanitizeHeader(to)}\r\n` +
           `Subject: ${this.sanitizeHeader(subject)}\r\n` +
           `Cc: ${cc.map((c: string) => this.sanitizeHeader(c)).join(', ')}\r\n` +
-          `Content-Type: text/plain; charset="UTF-8"\r\n` +
+          `Content-Type: ${rendered.contentType}; charset="UTF-8"\r\n` +
           `\r\n` +
-          `${body}`
+          `${rendered.body}`
         ).toString('base64url')
       };
 
@@ -826,6 +839,7 @@ export class GmailTools {
         throw new Error('Could not extract threadId from original message');
       }
 
+      const rendered = renderEmailBody(replyBody, args.body_type);
       const message = {
         raw: Buffer.from(
           `In-Reply-To: ${this.sanitizeHeader(originalMessageId)}\r\n` +
@@ -833,9 +847,9 @@ export class GmailTools {
           `Subject: Re: ${this.sanitizeHeader(headers.subject || '')}\r\n` +
           `To: ${this.sanitizeHeader(headers.from || '')}\r\n` +
           `Cc: ${cc.map((c: string) => this.sanitizeHeader(c)).join(', ')}\r\n` +
-          `Content-Type: text/plain; charset="UTF-8"\r\n` +
+          `Content-Type: ${rendered.contentType}; charset="UTF-8"\r\n` +
           `\r\n` +
-          `${replyBody}`
+          `${rendered.body}`
         ).toString('base64url'),
         threadId: threadId
       };


### PR DESCRIPTION
## Summary

- Add `body_type` (`plain` | `html` | `markdown`) to `gmail_create_draft` and `gmail_reply`.
- Default is `plain`, so existing callers see no behavior change.
- `html` sends the body verbatim as `text/html`.
- `markdown` renders via `marked` and sends as `text/html`.

Rendering lives in `src/tools/gmail-helpers.ts` (`renderEmailBody`) so it stays unit-testable without pulling `googleapis`.

## Why this rather than #18

#18 also addresses the same underlying gap (no HTML option), but does it by **flipping the default** to `text/html` and auto-converting plain text (`\n` → `<br>`). That is a behavior change for every existing caller, and the heuristic `/<[a-z][\s\S]*>/i.test(body)` will false-positive on bodies containing `<word>` fragments (code, generic angle-bracket text) and send them as HTML unescaped.

This PR keeps `text/plain` as the default and adds HTML / Markdown as explicit opt-ins.

## Test plan

- [x] `npm test` — 28 passing, including 6 new `renderEmailBody` cases (default, plain, html passthrough, markdown rendering, unknown fallback, sync string return).
- [x] Live MCP test against real Gmail: created plain / html / markdown drafts, verified each produced the right MIME body, then deleted them.