### PR TITLE
Fix multi-account credential bleed via per-account OAuth2Client cache

### DIFF
--- a/launch
+++ b/launch
@@ -13,4 +13,14 @@ then
   npm run build > /dev/null 2>&1
 fi
 
+# Node 22+ removed `SlowBuffer`, which `buffer-equal-constant-time@1.0.1`
+# (a transitive dep of `jwa` via `google-auth-library`) reads at module load.
+# Upstream package hasn't been updated since 2014; patch it in place each launch
+# so the patch survives `npm install`.
+BECT=node_modules/buffer-equal-constant-time/index.js
+if [ -f "$BECT" ] && grep -qF "require('buffer').SlowBuffer;" "$BECT"; then
+  # Use '#' as delimiter so the '||' in the replacement isn't mis-parsed as a delimiter (BSD sed).
+  sed -i.bak "s#require('buffer').SlowBuffer;#require('buffer').SlowBuffer || require('buffer').Buffer;#" "$BECT"
+fi
+
 node dist/server.js

--- a/src/services/gauth.ts
+++ b/src/services/gauth.ts
@@ -53,6 +53,9 @@ export class NoUserIdError extends Error {}
 
 export class GAuthService {
   private oauth2Client?: OAuth2Client;
+  private clientCache: Map<string, OAuth2Client> = new Map();
+  private clientId?: string;
+  private clientSecret?: string;
   private config: ServerConfig;
 
   constructor(config: ServerConfig) {
@@ -73,9 +76,11 @@ export class GAuthService {
         throw new Error('Invalid OAuth2 credentials format in gauth file');
       }
 
+      this.clientId = credentials.installed.client_id;
+      this.clientSecret = credentials.installed.client_secret;
       this.oauth2Client = new google.auth.OAuth2(
-        credentials.installed.client_id,
-        credentials.installed.client_secret,
+        this.clientId,
+        this.clientSecret,
         REDIRECT_URI
       );
     } catch (error) {
@@ -88,6 +93,27 @@ export class GAuthService {
       throw new Error('OAuth2 client not initialized. Call initialize() first.');
     }
     return this.oauth2Client;
+  }
+
+  // Per-account OAuth2Client. Falls back to the shared client only if no
+  // per-user client has been cached yet — callers should pair this with
+  // a prior getStoredCredentials(userId) call so the cache is populated.
+  getClientForUser(userId: string): OAuth2Client {
+    const client = this.clientCache.get(userId);
+    if (client) {
+      return client;
+    }
+    return this.getClient();
+  }
+
+  private createClientForUser(credentials: Credentials): OAuth2Client {
+    const client = new OAuth2Client(
+      this.clientId,
+      this.clientSecret,
+      REDIRECT_URI
+    );
+    client.setCredentials(credentials);
+    return client;
   }
 
   private getCredentialFilename(userId: string): string {
@@ -125,12 +151,18 @@ export class GAuthService {
       return null;
     }
 
+    const cached = this.clientCache.get(userId);
+    if (cached) {
+      return cached;
+    }
+
     try {
       const credFilePath = this.getCredentialFilename(userId);
       const data = await fs.readFile(credFilePath, 'utf8');
       const credentials = JSON.parse(data);
-      this.oauth2Client.setCredentials(credentials);
-      return this.oauth2Client;
+      const client = this.createClientForUser(credentials);
+      this.clientCache.set(userId, client);
+      return client;
     } catch (error) {
       console.warn(`No stored OAuth2 credentials yet for user: ${userId}`);
       return null;
@@ -181,7 +213,9 @@ export class GAuthService {
       access_type: 'offline',
       scope: SCOPES,
       state: JSON.stringify(state),
-      prompt: 'consent',
+      // Force the account picker so the user can't accidentally consent
+      // as the browser's default Google account when authenticating a different one.
+      prompt: 'select_account consent',
       login_hint: emailAddress
     });
   }
@@ -195,6 +229,8 @@ export class GAuthService {
 
       if (credentials.credentials.refresh_token) {
         await this.storeCredentials(credentials, emailAddress);
+        const client = this.createClientForUser(credentials.credentials);
+        this.clientCache.set(emailAddress, client);
         return credentials;
       } else {
         const storedCredentials = await this.getStoredCredentials(emailAddress);

--- a/src/tools/calendar.ts
+++ b/src/tools/calendar.ts
@@ -6,10 +6,11 @@ import { USER_ID_ARG } from '../types/tool-handler.js';
 const CALENDAR_ID_ARG = 'calendar_id';
 
 export class CalendarTools {
-  private calendar: ReturnType<typeof google.calendar>;
+  constructor(private gauth: GAuthService) {}
 
-  constructor(private gauth: GAuthService) {
-    this.calendar = google.calendar({ version: 'v3', auth: this.gauth.getClient() });
+  private getCalendarClient(userId: string) {
+    const client = this.gauth.getClientForUser(userId);
+    return google.calendar({ version: 'v3', auth: client });
   }
 
   getTools(): Tool[] {
@@ -233,9 +234,11 @@ export class CalendarTools {
       throw new Error(`Missing required argument: ${USER_ID_ARG}`);
     }
 
+    const calendar = this.getCalendarClient(userId);
+
     try {
       console.error('Attempting to list calendars...');
-      const response = await this.calendar.calendarList.list();
+      const response = await calendar.calendarList.list();
       const calendars = response.data.items?.map(calendar => ({
         id: calendar.id,
         summary: calendar.summary,
@@ -262,6 +265,8 @@ export class CalendarTools {
       throw new Error(`Missing required argument: ${USER_ID_ARG}`);
     }
 
+    const calendar = this.getCalendarClient(userId);
+
     try {
       const timeMin = args.time_min || new Date().toISOString();
       const maxResults = Math.min(Math.max(1, args.max_results || 250), 2500);
@@ -281,7 +286,7 @@ export class CalendarTools {
         Object.assign(params, { timeMax: args.time_max });
       }
 
-      const response = await this.calendar.events.list(params);
+      const response = await calendar.events.list(params);
       const events = response.data.items?.map(event => ({
         id: event.id,
         summary: event.summary,
@@ -319,6 +324,8 @@ export class CalendarTools {
       throw new Error(`Missing required arguments: ${required.filter(key => !(key in args)).join(', ')}`);
     }
 
+    const calendar = this.getCalendarClient(userId);
+
     try {
       const timezone = args.timezone || 'UTC';
       const event = {
@@ -336,7 +343,7 @@ export class CalendarTools {
         attendees: args.attendees?.map((email: string) => ({ email }))
       };
 
-      const response = await this.calendar.events.insert({
+      const response = await calendar.events.insert({
         calendarId: args[CALENDAR_ID_ARG] || 'primary',
         requestBody: event,
         sendUpdates: args.send_notifications ? 'all' : 'none'
@@ -363,8 +370,10 @@ export class CalendarTools {
       throw new Error('Missing required argument: event_id');
     }
 
+    const calendar = this.getCalendarClient(userId);
+
     try {
-      await this.calendar.events.delete({
+      await calendar.events.delete({
         calendarId: args[CALENDAR_ID_ARG] || 'primary',
         eventId: eventId,
         sendUpdates: args.send_notifications ? 'all' : 'none'

--- a/src/tools/gmail.ts
+++ b/src/tools/gmail.ts
@@ -9,10 +9,11 @@ import { decodeBase64Data, formatDraftEntry, renderEmailBody, resolveAttachmentP
 export { decodeBase64Data, formatDraftEntry, renderEmailBody, resolveAttachmentPath } from './gmail-helpers.js';
 
 export class GmailTools {
-  private gmail: ReturnType<typeof google.gmail>;
+  constructor(private gauth: GAuthService) {}
 
-  constructor(private gauth: GAuthService) {
-    this.gmail = google.gmail({ version: 'v1', auth: this.gauth.getClient() });
+  private getGmailClient(userId: string) {
+    const client = this.gauth.getClientForUser(userId);
+    return google.gmail({ version: 'v1', auth: client });
   }
 
   // Helper methods for email content extraction
@@ -503,8 +504,10 @@ export class GmailTools {
       throw new Error(`Missing required argument: ${USER_ID_ARG}`);
     }
 
+    const gmail = this.getGmailClient(userId);
+
     try {
-      const response = await this.gmail.users.messages.list({
+      const response = await gmail.users.messages.list({
         userId,
         q: args.query,
         maxResults: args.max_results || 100
@@ -513,7 +516,7 @@ export class GmailTools {
       const messages = response.data.messages || [];
       const emails = await Promise.all(
         messages.map(async (msg) => {
-          const email = await this.gmail.users.messages.get({
+          const email = await gmail.users.messages.get({
             userId,
             id: msg.id!,
             format: 'metadata',
@@ -560,8 +563,10 @@ export class GmailTools {
       throw new Error('Missing required argument: email_id');
     }
 
+    const gmail = this.getGmailClient(userId);
+
     try {
-      const email = await this.gmail.users.messages.get({
+      const email = await gmail.users.messages.get({
         userId,
         id: emailId,
         format: 'full'
@@ -619,10 +624,12 @@ export class GmailTools {
       throw new Error('Missing required argument: email_ids');
     }
 
+    const gmail = this.getGmailClient(userId);
+
     try {
       const emails = await Promise.all(
         emailIds.map(async (emailId: string) => {
-          const email = await this.gmail.users.messages.get({
+          const email = await gmail.users.messages.get({
             userId,
             id: emailId,
             format: 'full'
@@ -691,6 +698,8 @@ export class GmailTools {
       throw new Error('Missing required argument: body');
     }
 
+    const gmail = this.getGmailClient(userId);
+
     try {
       const rendered = renderEmailBody(body, args.body_type);
       const message = {
@@ -704,7 +713,7 @@ export class GmailTools {
         ).toString('base64url')
       };
 
-      const draft = await this.gmail.users.drafts.create({
+      const draft = await gmail.users.drafts.create({
         userId,
         requestBody: {
           message
@@ -727,8 +736,10 @@ export class GmailTools {
       throw new Error(`Missing required argument: ${USER_ID_ARG}`);
     }
 
+    const gmail = this.getGmailClient(userId);
+
     try {
-      const response = await this.gmail.users.drafts.list({
+      const response = await gmail.users.drafts.list({
         userId,
         q: args.query,
         maxResults: args.max_results || 100
@@ -739,7 +750,7 @@ export class GmailTools {
         drafts.map(async (d) => {
           const messageId = d.message?.id;
           if (!messageId) return null;
-          const msg = await this.gmail.users.messages.get({
+          const msg = await gmail.users.messages.get({
             userId,
             id: messageId,
             format: 'metadata',
@@ -782,8 +793,10 @@ export class GmailTools {
       throw new Error('Missing required argument: draft_id');
     }
 
+    const gmail = this.getGmailClient(userId);
+
     try {
-      await this.gmail.users.drafts.delete({
+      await gmail.users.drafts.delete({
         userId,
         id: draftId
       });
@@ -815,9 +828,11 @@ export class GmailTools {
       throw new Error('Missing required argument: reply_body');
     }
 
+    const gmail = this.getGmailClient(userId);
+
     try {
       // First get the original message to extract headers
-      const originalMessage = await this.gmail.users.messages.get({
+      const originalMessage = await gmail.users.messages.get({
         userId,
         id: originalMessageId
       });
@@ -855,7 +870,7 @@ export class GmailTools {
       };
 
       if (send) {
-        await this.gmail.users.messages.send({
+        await gmail.users.messages.send({
           userId,
           requestBody: {
             raw: message.raw,
@@ -867,7 +882,7 @@ export class GmailTools {
           text: 'Reply sent successfully'
         }];
       } else {
-        const draft = await this.gmail.users.drafts.create({
+        const draft = await gmail.users.drafts.create({
           userId,
           requestBody: {
             message
@@ -908,8 +923,10 @@ export class GmailTools {
       throw new Error('Missing required argument: filename');
     }
 
+    const gmail = this.getGmailClient(userId);
+
     try {
-      const attachment = await this.gmail.users.messages.attachments.get({
+      const attachment = await gmail.users.messages.attachments.get({
         userId,
         messageId,
         id: attachmentId
@@ -952,6 +969,8 @@ export class GmailTools {
       throw new Error('Missing required argument: attachments');
     }
 
+    const gmail = this.getGmailClient(userId);
+
     try {
       const results = await Promise.all(
         attachments.map(async (attachmentInfo: any) => {
@@ -963,7 +982,7 @@ export class GmailTools {
             throw new Error('Missing required arguments: message_id, part_id, or save_path');
           }
 
-          const attachmentData = await this.gmail.users.messages.attachments.get({
+          const attachmentData = await gmail.users.messages.attachments.get({
             userId,
             messageId,
             id: partId
@@ -1009,8 +1028,10 @@ export class GmailTools {
       throw new Error('Missing required argument: message_id');
     }
 
+    const gmail = this.getGmailClient(userId);
+
     try {
-      await this.gmail.users.messages.modify({
+      await gmail.users.messages.modify({
         userId,
         id: messageId,
         requestBody: {
@@ -1039,10 +1060,12 @@ export class GmailTools {
       throw new Error('Missing required argument: message_ids');
     }
 
+    const gmail = this.getGmailClient(userId);
+
     try {
       const results = await Promise.all(
         messageIds.map(async (messageId: string) => {
-          await this.gmail.users.messages.modify({
+          await gmail.users.messages.modify({
             userId,
             id: messageId,
             requestBody: {


### PR DESCRIPTION
The shared `OAuth2Client.setCredentials` pattern caused credentials to bleed between accounts when more than one was configured: every Gmail/Calendar request used whichever account had its tokens set last, and Google returned `Delegation denied for <other-account>` for any other userId.

- `gauth.ts`: introduce a per-account `OAuth2Client` cache populated lazily in `getStoredCredentials` and after a successful OAuth code exchange. Add `getClientForUser(userId)` so callers can fetch the per-account client without mutating shared state.
- `gmail.ts`, `calendar.ts`: tool methods now resolve a fresh client via `getGmailClient(userId)` / `getCalendarClient(userId)` at the top of each handler instead of capturing a shared client reference in the constructor.
- `gauth.ts`: `getAuthorizationUrl` now uses `prompt='select_account consent'` so the Google account picker is always shown — prevents accidental consent as the browser's default account when authenticating a different one.
- `launch`: in-place patch for `buffer-equal-constant-time` on Node 22+ (transitive dep references the removed `SlowBuffer`).

Based on the auth-layer changes from #14 by @felix-reiners, rebased onto current main and extended with the `select_account` prompt and the Node 25 compatibility shim.